### PR TITLE
fix: fixing minimum version of grpcio dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ tests = [
 ]
 protoc = [
     "grpcio-tools",
+    "grpcio==1.68.1",
 ]
 doc = [
     "Sphinx>=1.8.2",


### PR DESCRIPTION
The build-time grpcio need to be older that runtime one. Runtime is set to allows any version higher than 1.68.1. To be sure that any future build use this bottom version, the version is set strictly in build-depends `protoc` dependency list only.